### PR TITLE
fix script name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ sudo ./install.sh
 
 ### Usage
 ```text
-#> ./subwalker example.com
+#> ./subwalker.sh example.com
 [*] Executing SubWalker against: example.com
 [*] Launching SubScraper
 [*] Launching Sublist3r


### PR DESCRIPTION
find a small typo in the README.
with this command script will not run :
./subwalker example.com
the script's name must be write completely :
./subwalker.sh example.com